### PR TITLE
AMCR-89: master script fix - small pom submissions appearing in large files

### DIFF
--- a/dbo/Views/v_extract_recent_pom_org_small_data.sql
+++ b/dbo/Views/v_extract_recent_pom_org_small_data.sql
@@ -19,67 +19,69 @@ With Small_producer_recent_pom_org as
 			(Reporting_Year=2025	and Organisation_data_submission_period='July to Dec 2025 - H2')
 		)
 )
-select so.Org_ID
-,Org_name
-,CH_number
-,Nation_of_enrolment
-,Enrolment_date_time
-,Enrolment_status
-,Nation_of_Compliance_Scheme_regulator
-,case when so.Reporting_Year = 2024 then 'Jan to Dec 2024' when so.Reporting_Year = 2025 then 'Jan to Dec 2025' end as Packaging_data_submission_period
-,Packaging_data_first_submission_datetime
-,Packaging_data_first_submitted_CS_or_Direct
-,Packaging_data_first_submitted_CS_Nation
-,Packaging_data_first_submission_status
-,Packaging_data_first_submission_organisation_size
-,Packaging_data_latest_submission_datetime
-,Packaging_data_latest_submitted_CS_or_Direct
-,Packaging_data_latest_submitted_CS_Nation
-,Packaging_data_latest_submission_status
-,Packaging_data_latest_submission_organisation_size
-,case when so.Reporting_Year = 2024 then 'Jan to Dec 2025' when so.Reporting_Year = 2025 then 'Jan to Dec 2026' end as Organisation_data_submission_period
-,Organisation_data_first_submission_datetime
-,Organisation_data_first_submitted_CS_or_Direct
-,Organisation_data_first_submitted_CS_Nation
-,Organisation_data_first_submission_status
-,Organisation_data_first_submission_organisation_size
-,Organisation_data_latest_submission_datetime
-,Organisation_data_latest_submitted_CS_or_Direct
-,Organisation_data_latest_submitted_CS_Nation
-,Organisation_data_latest_submission_status
-,Organisation_data_latest_submission_organisation_size
-,Organisation_exists_in_most_recent_packaging_data_submission
-,Organisation_exists_in_most_recent_organisation_data_submission
-,Organisation_visible_in_PowerBI_Packaging_reports
-,Organisation_visible_in_PowerBI_Orgdata_reports
-,Single_File_Submission_Packaging
-,Single_File_Submission_Orgdata
-,ds.Reported_mandated_data_sets
-,Organisation_soft_deleted
-,[Household drinks containers-Aluminium (Kg)]
-,[Household drinks containers-Aluminium (No.Units)]
-,[Household drinks containers-Fibre Composite (Kg)]
-,[Household drinks containers-Fibre Composite (No.Units)]
-,[Household drinks containers-Glass (Kg)]
-,[Household drinks containers-Glass (No.Units)]
-,[Household drinks containers-Other (Kg)]
-,[Household drinks containers-Other (No.Units)]
-,[Household drinks containers-Paper / Card (Kg)]
-,[Household drinks containers-Paper / Card (No.Units)]
-,[Household drinks containers-Plastic (Kg)]
-,[Household drinks containers-Plastic (No.Units)]
-,[Household drinks containers-Steel (Kg)]
-,[Household drinks containers-Steel (No.Units)]
-,[Household drinks containers-Wood (Kg)]
-,[Household drinks containers-Wood (No.Units)]
-,[Small organisation packaging - all-Aluminium]
-,[Small organisation packaging - all-Fibre Composite]
-,[Small organisation packaging - all-Glass]
-,[Small organisation packaging - all-Other]
-,[Small organisation packaging - all-Paper / Card]
-,[Small organisation packaging - all-Plastic]
-,[Small organisation packaging - all-Steel]
-,[Small organisation packaging - all-Wood]
-,so.Reporting_Year
+
+select
+    so.Org_ID,
+    Org_name,
+    CH_number,
+    Nation_of_enrolment,
+    Enrolment_date_time,
+    Enrolment_status,
+    Nation_of_Compliance_Scheme_regulator,
+    case when so.Reporting_Year = 2024 then 'Jan to Dec 2024' when so.Reporting_Year = 2025 then 'Jan to Dec 2025' end as Packaging_data_submission_period,
+    Packaging_data_first_submission_datetime,
+    Packaging_data_first_submitted_CS_or_Direct,
+    Packaging_data_first_submitted_CS_Nation,
+    Packaging_data_first_submission_status,
+    Packaging_data_first_submission_organisation_size,
+    Packaging_data_latest_submission_datetime,
+    Packaging_data_latest_submitted_CS_or_Direct,
+    Packaging_data_latest_submitted_CS_Nation,
+    Packaging_data_latest_submission_status,
+    Packaging_data_latest_submission_organisation_size,
+    case when so.Reporting_Year = 2024 then 'Jan to Dec 2025' when so.Reporting_Year = 2025 then 'Jan to Dec 2026' end as Organisation_data_submission_period,
+    Organisation_data_first_submission_datetime,
+    Organisation_data_first_submitted_CS_or_Direct,
+    Organisation_data_first_submitted_CS_Nation,
+    Organisation_data_first_submission_status,
+    Organisation_data_first_submission_organisation_size,
+    Organisation_data_latest_submission_datetime,
+    Organisation_data_latest_submitted_CS_or_Direct,
+    Organisation_data_latest_submitted_CS_Nation,
+    Organisation_data_latest_submission_status,
+    Organisation_data_latest_submission_organisation_size,
+    Organisation_exists_in_most_recent_packaging_data_submission,
+    Organisation_exists_in_most_recent_organisation_data_submission,
+    Organisation_visible_in_PowerBI_Packaging_reports,
+    Organisation_visible_in_PowerBI_Orgdata_reports,
+    Single_File_Submission_Packaging,
+    Single_File_Submission_Orgdata,
+    ds.Reported_mandated_data_sets,
+    Organisation_soft_deleted,
+    [Household drinks containers-Aluminium (Kg)],
+    [Household drinks containers-Aluminium (No.Units)],
+    [Household drinks containers-Fibre Composite (Kg)],
+    [Household drinks containers-Fibre Composite (No.Units)],
+    [Household drinks containers-Glass (Kg)],
+    [Household drinks containers-Glass (No.Units)],
+    [Household drinks containers-Other (Kg)],
+    [Household drinks containers-Other (No.Units)],
+    [Household drinks containers-Paper / Card (Kg)],
+    [Household drinks containers-Paper / Card (No.Units)],
+    [Household drinks containers-Plastic (Kg)],
+    [Household drinks containers-Plastic (No.Units)],
+    [Household drinks containers-Steel (Kg)],
+    [Household drinks containers-Steel (No.Units)],
+    [Household drinks containers-Wood (Kg)],
+    [Household drinks containers-Wood (No.Units)],
+    [Small organisation packaging - all-Aluminium],
+    [Small organisation packaging - all-Fibre Composite],
+    [Small organisation packaging - all-Glass],
+    [Small organisation packaging - all-Other],
+    [Small organisation packaging - all-Paper / Card],
+    [Small organisation packaging - all-Plastic],
+    [Small organisation packaging - all-Steel],
+    [Small organisation packaging - all-Wood],
+    so.Reporting_Year
 from Small_producer_recent_pom_org so
 left join dbo.v_reported_mandated_data_sets ds on  ds.[Org_ID] = so.[Org_ID] and ds.ReportingYear = so.Reporting_Year;

--- a/dbo/Views/v_extract_recent_pom_org_small_data.sql
+++ b/dbo/Views/v_extract_recent_pom_org_small_data.sql
@@ -1,9 +1,5 @@
-﻿CREATE VIEW [dbo].[v_extract_recent_pom_org_small_data] AS With 
-/****************************************************************************************************************************
-	History:
-	Updated: 2025-09-01:	PM002:  Ticket - 607670:    Master script - Split file as small or Large for the year 2025
-******************************************************************************************************************************/
-Small_producer_recent_pom_org as
+﻿CREATE VIEW [dbo].[v_extract_recent_pom_org_small_data] AS
+With Small_producer_recent_pom_org as
 (
 	Select * from dbo.t_extract_recent_pom_org_data
 	where Organisation_data_first_submission_datetime is null and Organisation_data_latest_submission_datetime is null and Packaging_data_latest_submission_organisation_size ='S'
@@ -21,7 +17,7 @@ Small_producer_recent_pom_org as
 			(Reporting_Year=2024	and Organisation_data_submission_period='July to Dec 2024 - H2')
 			or
 			(Reporting_Year=2025	and Organisation_data_submission_period='July to Dec 2025 - H2')
-		) 
+		)
 )
 select so.Org_ID
 ,Org_name

--- a/dbo/Views/v_extract_recent_pom_org_small_data.sql
+++ b/dbo/Views/v_extract_recent_pom_org_small_data.sql
@@ -34,7 +34,7 @@ select
     Enrolment_date_time,
     Enrolment_status,
     Nation_of_Compliance_Scheme_regulator,
-    case when so.Reporting_Year = 2024 then 'Jan to Dec 2024' when so.Reporting_Year = 2025 then 'Jan to Dec 2025' end as Packaging_data_submission_period,
+    'Jan to Dec ' + reporting_year_str as Packaging_data_submission_period,
     Packaging_data_first_submission_datetime,
     Packaging_data_first_submitted_CS_or_Direct,
     Packaging_data_first_submitted_CS_Nation,
@@ -45,7 +45,7 @@ select
     Packaging_data_latest_submitted_CS_Nation,
     Packaging_data_latest_submission_status,
     Packaging_data_latest_submission_organisation_size,
-    case when so.Reporting_Year = 2024 then 'Jan to Dec 2025' when so.Reporting_Year = 2025 then 'Jan to Dec 2026' end as Organisation_data_submission_period,
+    'Jan to Dec ' + cast(reporting_year + 1 as nvarchar(4)) as Organisation_data_submission_period,
     Organisation_data_first_submission_datetime,
     Organisation_data_first_submitted_CS_or_Direct,
     Organisation_data_first_submitted_CS_Nation,
@@ -89,5 +89,6 @@ select
     [Small organisation packaging - all-Steel],
     [Small organisation packaging - all-Wood],
     so.Reporting_Year
-from Small_producer_recent_pom_org so
-left join dbo.v_reported_mandated_data_sets ds on  ds.[Org_ID] = so.[Org_ID] and ds.ReportingYear = so.Reporting_Year;
+from small_producer_recent_pom_org so
+left join dbo.v_reported_mandated_data_sets ds on  ds.[Org_ID] = so.[Org_ID]
+    and ds.ReportingYear = so.Reporting_Year;

--- a/dbo/Views/v_extract_recent_pom_org_small_data.sql
+++ b/dbo/Views/v_extract_recent_pom_org_small_data.sql
@@ -1,23 +1,29 @@
 ﻿CREATE VIEW [dbo].[v_extract_recent_pom_org_small_data] AS
-With Small_producer_recent_pom_org as
-(
-	Select * from dbo.t_extract_recent_pom_org_data
-	where Organisation_data_first_submission_datetime is null and Organisation_data_latest_submission_datetime is null and Packaging_data_latest_submission_organisation_size ='S'
-	and (
-			(Reporting_Year=2024 and Packaging_data_latest_submission_period_code ='2024-P0')
-			or
-			(Reporting_Year=2025 and Packaging_data_latest_submission_period_code ='2025-P0')
-		)
+with base as (
+    select *,
+        cast(Reporting_Year as varchar(4)) reporting_year_str
+    from dbo.t_extract_recent_pom_org_data
+    where 'S' in (Packaging_data_latest_submission_organisation_size, Organisation_data_latest_submission_organisation_size)
+    and Reporting_Year >= 2024
+),
+legacy as (
+    select * from base
+	where reporting_year in (2024, 2025)
+        and organisation_data_latest_submission_organisation_size = 'S'
+        and organisation_data_latest_submission_status not in ('Refused', 'Rejected', 'Cancelled')
+        and Organisation_data_submission_period = 'July to Dec ' + reporting_year_str + ' - H2'
+),
+
+small_producer_recent_pom_org as (
+	select * from base
+	where packaging_data_latest_submission_organisation_size = 'S'
+        and Organisation_data_first_submission_datetime is null
+        and Organisation_data_latest_submission_datetime is null
+        and Packaging_data_latest_submission_period_code = reporting_year_str + '-P0'
 
 	union all
 
-	Select * from dbo.t_extract_recent_pom_org_data
-	where Organisation_data_latest_submission_organisation_size='S'	and Organisation_data_latest_submission_status not in ('Refused','Rejected','Cancelled')
-	and (
-			(Reporting_Year=2024	and Organisation_data_submission_period='July to Dec 2024 - H2')
-			or
-			(Reporting_Year=2025	and Organisation_data_submission_period='July to Dec 2025 - H2')
-		)
+	select * from legacy
 )
 
 select


### PR DESCRIPTION
As per [AMCR-89](https://eaflood.atlassian.net/browse/AMCR-89), from 2026 `small pom`  uploads were getting into `large pom` files. This PR fixes it - so `small` pom uploads get reported in `small` excel files.

The main issue was that `Small_producer_recent_pom_org` CTE was only taking into account records for `2024 & 2025`. We've removed this upper limit `Reporting_Year >= 2024`

Performance stats are here -> https://eaflood.atlassian.net/browse/AMCR-89?focusedCommentId=842810

[AMCR-89]: https://eaflood.atlassian.net/browse/AMCR-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ