### PR TITLE
Emr 497 v2 clr reporting

### DIFF
--- a/dbo/Stored Procedures/GetLatestAcceptedGrantedOrgData.sql
+++ b/dbo/Stored Procedures/GetLatestAcceptedGrantedOrgData.sql
@@ -1,6 +1,9 @@
-﻿CREATE PROC [dbo].[GetLatestAcceptedGrantedOrgData] @createdOrModifiedAfter [nvarchar](200) AS
+﻿CREATE PROC [dbo].[GetLatestAcceptedGrantedOrgData]
+    @createdOrModifiedAfter [nvarchar](200) = NULL,
+    @relativeYear INT = NULL
+AS
 BEGIN
-		DECLARE @start_dt datetime;
+	DECLARE @start_dt datetime;
 	DECLARE @batch_id INT;
 	DECLARE @cnt int;
 
@@ -10,14 +13,18 @@ BEGIN
     BEGIN
     WITH CTE AS (SELECT *
         FROM [rpd].[LatestAcceptedGrantedOrg]
-        where CONVERT(DATETIME,substring(LastUpdatedOn,1,23)) >= CONVERT(DATETIME,substring(@createdOrModifiedAfter,1,23)))
+        where CONVERT(DATETIME,substring(LastUpdatedOn,1,23)) >= CONVERT(DATETIME,substring(@createdOrModifiedAfter,1,23))
+        AND (@relativeYear IS NULL OR relativeYear = @relativeYear))
+
         SELECT * FROM rpd.LatestAcceptedGrantedOrg lago
         WHERE EXISTS (SELECT organisation_id FROM CTE WHERE lago.[organisation_id] = CTE.organisation_id)
+        AND (@relativeYear IS NULL OR lago.relativeYear = @relativeYear)
         END
     ELSE
     BEGIN
         SELECT *
         FROM [rpd].[LatestAcceptedGrantedOrg]
+        WHERE (@relativeYear IS NULL OR relativeYear = @relativeYear);
         END
 
 	INSERT INTO [dbo].[batch_log] ([ID],[ProcessName],[SubProcessName],[Count],[start_time_stamp],[end_time_stamp],[Comments],batch_id)

--- a/dbo/Stored Procedures/GetLatestAcceptedGrantedOrgData.sql
+++ b/dbo/Stored Procedures/GetLatestAcceptedGrantedOrgData.sql
@@ -1,6 +1,6 @@
 ﻿CREATE PROC [dbo].[GetLatestAcceptedGrantedOrgData]
-    @createdOrModifiedAfter [nvarchar](200) = NULL,
-    @relativeYear INT = NULL
+    @createdOrModifiedAfter [nvarchar](200),
+    @relativeYear INT
 AS
 BEGIN
 	DECLARE @start_dt datetime;

--- a/dbo/Views/v_POM_Aggregated_Packaging_Order.sql
+++ b/dbo/Views/v_POM_Aggregated_Packaging_Order.sql
@@ -1,87 +1,67 @@
-﻿CREATE VIEW [dbo].[v_POM_Aggregated_Packaging_Order] AS with cte_packaging as (
+﻿CREATE VIEW [dbo].[v_POM_Aggregated_Packaging_Order] 
 /****************************************************************************************************************************
 	History:
  
 	Updated: 2024-11-19:	YM001:	Ticket - 460891:	Added (packaging_type = 'SP' as 'Small organisation packaging - all') as part of small producer change
 	Updated: 2024-11-25:	SN002:  Ticket - 460891:	Added (packaging_type_inc_OrgSize which shows breakdow	'Household drinks containers' between large and small producers (SP)'
 	Updated: 2024-12-02:	SN003:  Ticket - 460891:	changed to use packaging type code, not full description. Changed JOinColumn name to PkgOrgJoinColumn
-	
+	Updated: 2026-07-10:	EMR-497				   :	Added in CLR via POM_Codes so can be centrally managed and bring through CLR packaging types.
 						
 ******************************************************************************************************************************/
-    SELECT distinct p.packaging_type as packaging_type_code
+AS with cte_packaging as (
+	SELECT distinct p.packaging_type as packaging_type_code
+		, ptc.[Text] AS packaging_type
+		,case
+			when p.packaging_type = 'CW' then 1
+			when p.packaging_type = 'OW' then 2
+			when p.packaging_type = 'HH' then 3
+			when p.packaging_type = 'NH' then 5
+			when p.packaging_type = 'HDC' then 6
+			when p.packaging_type = 'NDC' then 7
+			when p.packaging_type = 'PB' then 4 --changed order
+			when p.packaging_type = 'RU' then 8
+			when p.packaging_type = 'SP' then 9 /**YM001 **/
+			when p.packaging_type = 'CLR' then 10
+		  ELSE  -1
+		end packaging_type_order
 
-    ,case
-    when p.packaging_type = 'CW' then 'Self-managed consumer waste'
-    when p.packaging_type = 'OW' then 'Self-managed organisation waste'
-    when p.packaging_type = 'HH' then 'Total Household packaging'
-    when p.packaging_type = 'NH' then 'Total Non-Household packaging'
-    when p.packaging_type = 'HDC' then 'Household drinks containers'
-    when p.packaging_type = 'NDC' then 'Non-household drinks containers'
-    when p.packaging_type = 'PB' then 'Public binned'
-    when p.packaging_type = 'RU' then 'Reusable packaging'
-	when p.packaging_type = 'SP' then 'Small organisation packaging - all' /**YM001 **/
-    end packaging_type
-
-    ,case
-    when p.packaging_type = 'CW' then 1
-    when p.packaging_type = 'OW' then 2
-    when p.packaging_type = 'HH' then 3
-    when p.packaging_type = 'NH' then 5
-    when p.packaging_type = 'HDC' then 6
-    when p.packaging_type = 'NDC' then 7
-    when p.packaging_type = 'PB' then 4 --changed order
-    when p.packaging_type = 'RU' then 8
-	when p.packaging_type = 'SP' then 9 /**YM001 **/
-    end packaging_type_order
-
-    ,packaging_class
-	,organisation_size /** SN002 ^^^ **/
-	,concat(p.packaging_type,'-',packaging_class) as Ignore_column
-    from rpd.Pom p
-    where packaging_type in (
-        'CW', 'OW', 'HH', 'NH',
-        'HDC', 'NDC', 'PB', 'RU','SP' /**YM001 **/
-    ) 
-)
+		,packaging_class AS packaging_class_code
+		,pcc.[Text] AS packaging_class
+		,case
+			when packaging_class = 'P1' then 1
+			when packaging_class = 'P2' then 2
+			when packaging_class = 'P3' then 3
+			when packaging_class = 'P4' then 5
+			when packaging_class = 'P5' then 6
+			when packaging_class = 'P6' then 7
+			when packaging_class = 'O1' then 8
+			when packaging_class = 'O2' then 9
+			when packaging_class = 'B1' then 4
+			ELSE -1
+		end packaging_class_order
+		,organisation_size /** SN002 ^^^ **/
+		,concat(p.packaging_type,'-',packaging_class) as Ignore_column
+		from rpd.Pom p
+		INNER JOIN [dbo].[t_PoM_Codes] ptc ON ptc.Code = p.packaging_type AND ptc.[Type] = 'packaging_type'
+		LEFT JOIN [dbo].[t_PoM_Codes] pcc ON pcc.Code = p.packaging_class AND pcc.[Type] = 'packaging_class'
+	)
 
 select packaging_type_code
-,packaging_type
-,packaging_type_order
-,Ignore_column
-
-,case
-    when packaging_class = 'P1' then 'Primary packaging'
-    when packaging_class = 'P2' then 'Secondary packaging'
-    when packaging_class = 'P3' then 'Shipment packaging'
-    when packaging_class = 'P4' then 'Tertiary packaging'
-    when packaging_class = 'P5' then 'Non-primary reusable packaging'
-    when packaging_class = 'P6' then 'Online marketplace total'
-    when packaging_class = 'O1' then 'Consumer waste'
-    when packaging_class = 'O2' then 'Organisation waste'
-    when packaging_class = 'B1' then 'Public bin'
-    else packaging_class
-end packaging_class
-
-,case
-    when packaging_class = 'P1' then 1
-    when packaging_class = 'P2' then 2
-    when packaging_class = 'P3' then 3
-    when packaging_class = 'P4' then 5
-    when packaging_class = 'P5' then 6
-    when packaging_class = 'P6' then 7
-    when packaging_class = 'O1' then 8
-    when packaging_class = 'O2' then 9
-    when packaging_class = 'B1' then 4
-end packaging_class_order
- /** SN002 vvv **/
+	,packaging_type
+	,packaging_type_order
+	,Ignore_column
+	,packaging_class_code
+	,packaging_class
+	,packaging_class_order
+	/** SN002 vvv **/
 	,packaging_type_inc_OrgSize = Case When packaging_type = 'Household drinks containers' Then
-									Case organisation_size
-										When 'L' Then 'Household drinks containers (LP)'
-										When 'S' Then 'Household drinks containers (SP)'
-										Else 'Household drinks containers (Not Set)'  
-									End
-									Else packaging_type 
-									End
+										Case organisation_size
+											When 'L' Then 'Household drinks containers (LP)'
+											When 'S' Then 'Household drinks containers (SP)'
+											Else 'Household drinks containers (Not Set)'  
+										End
+										Else packaging_type 
+										End
 	/** SN002 ^^^ **/
-	,PkgOrgJoinColumn = Concat(packaging_type_code,'-',organisation_size)		 /** SN003 **/
+	,PkgOrgJoinColumn = Concat(packaging_type_code,'-',organisation_size) /** SN003 **/
 from cte_packaging;

--- a/dbo/Views/v_POM_Packaging_Order.sql
+++ b/dbo/Views/v_POM_Packaging_Order.sql
@@ -1,59 +1,37 @@
-﻿CREATE VIEW [dbo].[v_POM_Packaging_Order] AS With pkg as (
-Select Distinct
+﻿CREATE VIEW [dbo].[v_POM_Packaging_Order] 
 /****************************************************************************************************************************
 	History:
  
 	Updated: 2024-11-21:	YM001:	Ticket - 460891:	Added (packaging_type = 'SP' as 'Small organisation packaging - all') as part of small producer change
 	Updated: 2024-11-25:	SN002:  Ticket - 460891:	Added (packaging_type_inc_OrgSize which shows breakdow	'Household drinks containers' between large and small producers (SP)'
 	Updated: 2024-12-02:	SN003:  Ticket - 460891:	changed to use packaging type code, not full description. Changed JOinColumn name to PkgOrgJoinColumn
+	Updated: 2026-07-10:	EMR-497				   :	Added in CLR via POM_Codes so can be centrally managed and bring through CLR packaging types.
 		
 ******************************************************************************************************************************/
-p.packaging_type as packaging_type_code
 
-,case
-when p.packaging_type = 'CW' then 'Self-managed consumer waste'
-when p.packaging_type = 'OW' then 'Self-managed organisation waste'
-when p.packaging_type = 'HH' then 'Total Household packaging'
-when p.packaging_type = 'NH' then 'Total Non-Household packaging'
-when p.packaging_type = 'PB' then 'Public binned'
-when p.packaging_type = 'RU' then 'Reusable packaging'
-when p.packaging_type = 'HDC' then 'Household drinks containers'
-when p.packaging_type = 'NDC' then 'Non-household drinks containers'
-when p.packaging_type = 'SP' then 'Small organisation packaging - all' /**YM001 **/
-end packaging_type
+AS 
+	 
+With pkg as (
+	Select Distinct p.packaging_type as packaging_type_code
+		,ptc.[Text] AS packaging_type
+		,case
+			when p.packaging_type = 'CW' then 1
+			when p.packaging_type = 'OW' then 2
+			when p.packaging_type = 'HH' then 3
+			when p.packaging_type = 'NH' then 5
+			when p.packaging_type = 'HDC' then 6
+			when p.packaging_type = 'NDC' then 7
+			when p.packaging_type = 'PB' then 4 --changed order
+			when p.packaging_type = 'RU' then 8
+			when p.packaging_type = 'SP' then 9 /**YM001 **/
+			when p.packaging_type = 'CLR' then 10
+		end packaging_type_order
 
-,case
-when p.packaging_type = 'CW' then 1
-when p.packaging_type = 'OW' then 2
-when p.packaging_type = 'HH' then 3
-when p.packaging_type = 'NH' then 4
-when p.packaging_type = 'PB' then 5
-when p.packaging_type = 'RU' then 6
-when p.packaging_type = 'HDC' then 3
-when p.packaging_type = 'NDC' then 4
-when p.packaging_type = 'SP' then 7 /**YM001 **/
-end packaging_type_order
-
--- Section added for bug 233562; grouping HDC and NDC into Household/non-household waste. Used in POM summary report.
-,case 
-when p.packaging_type = 'CW' then 'Self-managed consumer waste'
-when p.packaging_type = 'OW' then 'Self-managed organisation waste'
-when p.packaging_type = 'HH' then 'Total Household packaging'
-when p.packaging_type = 'NH' then 'Total Non-Household packaging'
-when p.packaging_type = 'PB' then 'Public binned'
-when p.packaging_type = 'RU' then 'Reusable packaging'
-when p.packaging_type = 'HDC' then 'Total Household packaging'
-when p.packaging_type = 'NDC' then 'Total Non-Household packaging'
-when p.packaging_type = 'SP' then 'Small organisation packaging - all' /**YM001 **/
-end packaging_type_group
-,organisation_size
-from rpd.Pom p
-where packaging_type in (
-    'CW', 'OW', 'HH',
-    'NH', 'PB', 'RU',
-    'HDC', 'NDC','SP'/**YM001 **/
-)
-
+		-- Section added for bug 233562; grouping HDC and NDC into Household/non-household waste. Used in POM summary report.
+		,ptc.[Text] AS packaging_type_group
+		,organisation_size
+	from rpd.Pom p
+	INNER JOIN [dbo].[t_PoM_Codes] ptc ON ptc.Code = p.packaging_type AND ptc.[Type] = 'packaging_type'
 )
 
 Select 


### PR DESCRIPTION
Updating to include CLR in [dbo].[v_POM_Packaging_Order] and [dbo].[v_POM_Aggregated_Packaging_Order]
Previously manually isolated the packaging types in a case statment swopped to use the POM_codes table to better manage the code type values INNER joined in place of named types so next time as the type is added it will organically come through rather than multiple changes like with CLR.